### PR TITLE
Accept arguments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SOURCE_OF_TERMS=[path-or-url-to-file]
+VOCABULARY=[carriers|etc]

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'nypl_log_formatter', '~> 0.1.3'
+
 group :development, :test do
   gem 'pry', '~> 0.11.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     coderay (1.1.2)
     method_source (0.9.2)
+    nypl_log_formatter (0.1.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -11,7 +12,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  nypl_log_formatter (~> 0.1.3)
   pry (~> 0.11.3)
 
 BUNDLED WITH
-   1.13.6
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Locally - you can point it to [a dockerized Solr 3.5 that has a core named "auth
 
 1.  `docker-compose up`
 
+## Running authoritydata_updater.rb
+
+Looking at [docker-compose.yml](./docker-compose.yml), locally we pass in the values to the `--source` and `--vocabulary` options
+through the environment variables in .env In production, we'd probably just set the values when we overwrite entrypoint.
+
+## Confirming Solr Is Up
+
 You can confirm that your solr core exists by going to: `http://localhost:8983/solr/admin/cores?action=STATUS&core=authoritydata`
 You can see the Solr admin interface here: http://localhost:8983/solr/admin/
 

--- a/authoritydata_updater.rb
+++ b/authoritydata_updater.rb
@@ -1,1 +1,44 @@
-puts 'Hey, so I ran...'
+require 'optparse'
+require File.join('.', 'lib', 'vocabulary_parser')
+
+options = {}
+SUPPORTED_VOCABULARIES = ['carriers'].freeze
+
+opt_parser = OptionParser.new do |opts|
+  opts.banner = 'Usage: ruby authoritydata_udpater.rb [options] \n Exaxmple: ruby authoritydata_udpater.rb --authority carriers --source http://example.com/authority-file.xml'
+  opts.separator ''
+  opts.separator "Supported vocabularie: #{SUPPORTED_VOCABULARIES.join(', ')}"
+  opts.separator ''
+
+  opts.on('-v=', '--vocabulary', 'The type of vocabularies in the source file') do |vocabulary|
+    options[:vocabulary] = vocabulary
+  end
+
+  opts.on('-s=', '--source', 'Path or URL to vocabulary file') do |source|
+    options[:source] = source
+  end
+
+  opts.on_tail('-h', '--help', 'Show this message') do
+    puts opts
+    exit
+  end
+end
+
+opt_parser.parse!
+
+# TODO: These's probably a nicer way to raise these exceptions or move this
+# into VocabularyParser's initializer
+unless SUPPORTED_VOCABULARIES.include?(options[:vocabulary])
+  puts "You need to use a supported vocabulary like: #{SUPPORTED_VOCABULARIES.join(', ')}."
+  puts opt_parser
+  exit
+end
+
+if options[:source].nil?
+  puts 'You need to supply a path or URL to the vocabulary file'
+  puts opt_parser
+  exit
+end
+
+parser = VocabularyParser.new(vocabulary: options[:vocabulary], source: options[:source])
+parser.parse!

--- a/authoritydata_updater.rb
+++ b/authoritydata_updater.rb
@@ -1,5 +1,5 @@
 require 'optparse'
-require File.join('.', 'lib', 'vocabulary_parser')
+require File.join(__dir__, 'lib', 'vocabulary_parser')
 
 options = {}
 SUPPORTED_VOCABULARIES = ['carriers'].freeze

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./.env
     volumes:
       - '.:/opt/authoritydata_udpater'
+    entrypoint: ruby /opt/authoritydata_udpater/authoritydata_updater.rb --vocabulary $VOCABULARY --source $SOURCE_OF_TERMS
     depends_on:
     - solr
   solr:

--- a/lib/vocabulary_parser.rb
+++ b/lib/vocabulary_parser.rb
@@ -1,0 +1,12 @@
+class VocabularyParser
+  attr_reader :source, :vocabulary
+
+  def initialize(vocabulary: nil, source: nil)
+    @source = source
+    @vocabulary = vocabulary
+  end
+
+  def parse!
+    puts "Ho hum - I'll parse #{@vocabulary} from #{@source}"
+  end
+end

--- a/lib/vocabulary_parser.rb
+++ b/lib/vocabulary_parser.rb
@@ -1,12 +1,16 @@
+require 'nypl_log_formatter'
+
 class VocabularyParser
   attr_reader :source, :vocabulary
 
   def initialize(vocabulary: nil, source: nil)
+    @logger = NyplLogFormatter.new(STDOUT, level: 'debug')
+
     @source = source
     @vocabulary = vocabulary
   end
 
   def parse!
-    puts "Ho hum - I'll parse #{@vocabulary} from #{@source}"
+    @logger.info("Ho hum - I'll parse #{@vocabulary} from #{@source}")
   end
 end


### PR DESCRIPTION
Hey @emu47

authoritydata_updater.rb now accepts two arguments: `--vocabulary` and `--source`.
Locally, you can set these in .env...but in production we'll just set it in the entry point.

This also introduces the `VocabularyParser` class.
It's instantiated with two arguments: (`vocabulary:` and `source:`).

I believe `parse!()` is where we'll start the parsing.

**Since this PR introduces a new gem, you'll have to run `docker-compose build` again.**