### PR TITLE
Reject statements we dont care about

### DIFF
--- a/lib/tripple_to_solr_doc.rb
+++ b/lib/tripple_to_solr_doc.rb
@@ -7,11 +7,31 @@ require 'redis'
 include RDF
 
 class TrippleToSolrDoc
+  NS_TYPE_TO_TERM_TYPE_MAPPING = {
+    'http://www.loc.gov/mads/rdf/v1#Topic' => 'topic',
+    'http://www.loc.gov/mads/rdf/v1#Geographic' => 'geographic',
+    'http://www.loc.gov/mads/rdf/v1#PersonalName' => 'name_personal',
+    'http://www.loc.gov/mads/rdf/v1#ComplexSubject' => 'complex_subject',
+    'http://www.loc.gov/mads/rdf/v1#CorporateName' => 'name_corporate',
+    'http://www.loc.gov/mads/rdf/v1#GenreForm' => 'genreform',
+    'http://www.loc.gov/mads/rdf/v1#Temporal' => 'temporal',
+    'http://www.loc.gov/mads/rdf/v1#NameTitle' => 'name_title',
+    'http://www.loc.gov/mads/rdf/v1#Title' => 'title',
+    'http://www.loc.gov/mads/rdf/v1#ConferenceName' => 'name_conference'
+  }.freeze
+
+  WORTHWHILE_PREDICATES = [
+    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+    'http://www.loc.gov/mads/rdf/v1#adminMetadata',
+    'http://id.loc.gov/ontologies/RecordInfo#recordStatus',
+    'http://www.loc.gov/mads/rdf/v1#authoritativeLabel',
+    'http://www.w3.org/2004/02/skos/core#prefLabel'
+  ].freeze
+
   @@logger = NyplLogFormatter.new(STDOUT, level: 'debug')
   @@redis = Redis.new(url: ENV['REDIS_URL'])
 
   def self.convert!(file:, term_type:, authority_code:, authority_name:, unique_id_prefix:)
-
     statement_count = 0
 
     File.open(file, 'r').each do |line|
@@ -44,15 +64,15 @@ class TrippleToSolrDoc
               # We've never seen this subject before
 
               if predicate_string == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
-                inital_hash = Marshal.dump({predicate_string => [statement.object.to_s]})
+                inital_hash = Marshal.dump(predicate_string => [statement.object.to_s])
                 @@redis.set(subject_url, inital_hash)
               else
-                initial_hash = Marshal.dump({predicate_string => statement.object.to_s})
+                initial_hash = Marshal.dump(predicate_string => statement.object.to_s)
                 @@redis.set(subject_url, initial_hash)
               end
             end
           else
-            @@logger.info("skipping a statement")
+            @@logger.info('skipping a statement')
           end
         end
       end
@@ -67,49 +87,47 @@ class TrippleToSolrDoc
     #  ...and looking at _:bnode12683670136320746870
     #  :bnode12683670136320746870 <http://id.loc.gov/ontologies/RecordInfo#recordStatus'> "deprecated"
     @@redis.scan_each do |subject|
-        attributes = Marshal.load(@@redis.get(subject))
-        change_history = attributes['http://www.loc.gov/mads/rdf/v1#adminMetadata']
-        bnode_for_this = @@redis.get(change_history)
+      attributes = Marshal.load(@@redis.get(subject))
+      change_history = attributes['http://www.loc.gov/mads/rdf/v1#adminMetadata']
+      bnode_for_this = @@redis.get(change_history)
 
-        if change_history && bnode_for_this
-          bnodes_hash = Marshal.load(bnode_for_this)
-          if bnodes_hash['http://id.loc.gov/ontologies/RecordInfo#recordStatus'] == 'deprecated'
-            @@redis.del(subject)
-          end
+      if change_history && bnode_for_this
+        bnodes_hash = Marshal.load(bnode_for_this)
+        if bnodes_hash['http://id.loc.gov/ontologies/RecordInfo#recordStatus'] == 'deprecated'
+          @@redis.del(subject)
         end
+      end
     end
 
     @@logger.info("after weeding out deprecated there were #{@@redis.dbsize}")
 
     # Weed out bnodes, you have to do this after weeding out deprecateds, not at the same time
     @@redis.scan_each do |subject|
-      unless subject.include?('http')
-        @@redis.del(subject)
-      end
+      @@redis.del(subject) unless subject.include?('http')
     end
 
     @@logger.info("after weeding out bnodes there were #{@@redis.dbsize}")
 
     solr_docs = []
     @@redis.scan_each do |subject|
-        attributes = Marshal.load(@@redis.get(subject))
+      attributes = Marshal.load(@@redis.get(subject))
 
-        new_document = {
-          uri: subject,
-          term: attributes.dig('http://www.loc.gov/mads/rdf/v1#authoritativeLabel'),
-          term_idx: attributes.dig('http://www.loc.gov/mads/rdf/v1#authoritativeLabel'),
-          term_type: term_type == :auto ? detect_term_type(attributes) : term_type,
-          record_id: File.basename(subject),
-          language: 'en',
-          authority_code: authority_code,
-          authority_name: authority_name,
-          unique_id: "#{unique_id_prefix}_#{File.basename(subject)}",
-          alternate_term_idx: attributes.dig('http://www.w3.org/2004/02/skos/core#prefLabel'),
-          alternate_term: attributes.dig('http://www.w3.org/2004/02/skos/core#prefLabel')
-        }
+      new_document = {
+        uri: subject,
+        term: attributes.dig('http://www.loc.gov/mads/rdf/v1#authoritativeLabel'),
+        term_idx: attributes.dig('http://www.loc.gov/mads/rdf/v1#authoritativeLabel'),
+        term_type: term_type == :auto ? detect_term_type(attributes) : term_type,
+        record_id: File.basename(subject),
+        language: 'en',
+        authority_code: authority_code,
+        authority_name: authority_name,
+        unique_id: "#{unique_id_prefix}_#{File.basename(subject)}",
+        alternate_term_idx: attributes.dig('http://www.w3.org/2004/02/skos/core#prefLabel'),
+        alternate_term: attributes.dig('http://www.w3.org/2004/02/skos/core#prefLabel')
+      }
 
-        solr_docs << new_document
-      end
+      solr_docs << new_document
+    end
     solr_docs
   end
 
@@ -118,34 +136,11 @@ class TrippleToSolrDoc
   # As we parse the N-tripple file, we can skip even considering
   # this line if it's dealing with a predicate we don't care about (e.g. http://www.w3.org/2000/01/rdf-schema#seeAlso)
   def self.worthwhile_statement?(statement)
-    # TODO: worthehile_predicates can be factored out into a class constant
-    worthwhile_predicates = [
-      'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
-      'http://www.loc.gov/mads/rdf/v1#adminMetadata',
-      'http://id.loc.gov/ontologies/RecordInfo#recordStatus',
-      'http://www.loc.gov/mads/rdf/v1#authoritativeLabel',
-      "http://www.w3.org/2004/02/skos/core#prefLabel"
-    ]
-
-    worthwhile_predicates.include?(statement.predicate.to_s)
+    WORTHWHILE_PREDICATES.include?(statement.predicate.to_s)
   end
 
   def self.detect_term_type(predicate_to_object_mapping)
-    # TODO: term_types can be factored out into a class constant
-    term_types = {
-      'http://www.loc.gov/mads/rdf/v1#Topic' => 'topic',
-      'http://www.loc.gov/mads/rdf/v1#Geographic' => 'geographic',
-      'http://www.loc.gov/mads/rdf/v1#PersonalName' => 'name_personal',
-      'http://www.loc.gov/mads/rdf/v1#ComplexSubject' => 'complex_subject',
-      'http://www.loc.gov/mads/rdf/v1#CorporateName' => 'name_corporate',
-      'http://www.loc.gov/mads/rdf/v1#GenreForm' => 'genreform',
-      'http://www.loc.gov/mads/rdf/v1#Temporal' => 'temporal',
-      'http://www.loc.gov/mads/rdf/v1#NameTitle' => 'name_title',
-      'http://www.loc.gov/mads/rdf/v1#Title' => 'title',
-      'http://www.loc.gov/mads/rdf/v1#ConferenceName' => 'name_conference'
-    }
-
-    terms = term_types.keys
+    terms = NS_TYPE_TO_TERM_TYPE_MAPPING.keys
     ns_types = predicate_to_object_mapping.dig('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
 
     term_types[(terms & ns_types)&.first]


### PR DESCRIPTION
We only care about statements that contain certain predicates.
For example, the predicate "http://www.w3.org/2000/01/rdf-schema#seeAlso" doesn't
affect, in any way, what we post to Solr.

This results in faster parsing time and **smaller data structure** (Redis for now).

**This diff looks weird but I'm only wrapping our work in the `if worthwhile_statement?(statement)` statement.**

## How much faster?

Without Rejection I was parsing 2,645,700 statements per/hour in the name authorities file.
With Rejection I was parsing 4,073,200  statements per/hour in the name authorities file.

## Results

### Genre/Form Output

```json
{"level":"INFO","message":"before weeding out there were 24880","timestamp":"2019-09-05T01:53:19.326+0000"}
{"level":"INFO","message":"after weeding out deprecated there were 24749","timestamp":"2019-09-05T01:53:34.906+0000"}
{"level":"INFO","message":"after weeding out bnodes there were 2090","timestamp":"2019-09-05T01:53:42.372+0000"}
{"level":"DEBUG","message":"deleting by query: authority_code:lcgft","timestamp":"2019-09-05T01:53:43.125+0000"}
{"level":"INFO","message":"delete response: {\"responseHeader\"=>{\"status\"=>0, \"QTime\"=>115}}","timestamp":"2019-09-05T01:53:43.337+0000"}
{"level":"INFO","message":"commit response: {\"responseHeader\"=>{\"status\"=>0, \"QTime\"=>10}}","timestamp":"2019-09-05T01:53:43.353+0000"}
{"level":"INFO","message":"Finished posting genre_and_form from /opt/authoritydata_udpater/authoritiesgenreForms.madsrdf.nt to http://solr:8983/solr","timestamp":"2019-09-05T01:53:44.504+0000"}
```
I've tested it on genre/form and got the familiar numbers posted to solr at the end and well formed solr docs getting posted.

### Example Solr Query

http://localhost:8983/solr/select/?q=authority_code:lcgft&version=2.2&start=0&rows=19&indent=on&wt=json

```json
{
  "responseHeader":{
    "status":0,
    "QTime":2},
  "response":{"numFound":2090,"start":0,"docs":[
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026340",
        "term":"Fictional autobiographies",
        "term_idx":"Fictional autobiographies",
        "term_idx":"Fictional autobiographies",
        "term_type":"genreform",
        "record_id":"gf2014026340",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026340"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2011026060",
        "term":"Audience participation radio programs",
        "term_idx":"Audience participation radio programs",
        "term_idx":"Audience participation radio programs",
        "term_type":"genreform",
        "record_id":"gf2011026060",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2011026060"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026028",
        "term":"Cowboy poetry",
        "term_idx":"Cowboy poetry",
        "term_idx":"Cowboy poetry",
        "term_type":"genreform",
        "record_id":"gf2014026028",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026028"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026110",
        "term":"Humor",
        "term_idx":"Humor",
        "term_idx":"Humor",
        "term_type":"genreform",
        "record_id":"gf2014026110",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026110"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2011026169",
        "term":"Cookbooks",
        "term_idx":"Cookbooks",
        "term_idx":"Cookbooks",
        "term_type":"genreform",
        "record_id":"gf2011026169",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2011026169"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026288",
        "term":"Didactic fiction",
        "term_idx":"Didactic fiction",
        "term_idx":"Didactic fiction",
        "term_type":"genreform",
        "record_id":"gf2014026288",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026288"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2011026521",
        "term":"Reality radio programs",
        "term_idx":"Reality radio programs",
        "term_idx":"Reality radio programs",
        "term_type":"genreform",
        "record_id":"gf2011026521",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2011026521"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026678",
        "term":"Cadenzas",
        "term_idx":"Cadenzas",
        "term_idx":"Cadenzas",
        "term_type":"genreform",
        "record_id":"gf2014026678",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026678"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026589",
        "term":"War comics",
        "term_idx":"War comics",
        "term_idx":"War comics",
        "term_type":"genreform",
        "record_id":"gf2014026589",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026589"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026155",
        "term":"Programmed instructional materials",
        "term_idx":"Programmed instructional materials",
        "term_idx":"Programmed instructional materials",
        "term_type":"genreform",
        "record_id":"gf2014026155",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026155"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026164",
        "term":"Recreational works",
        "term_idx":"Recreational works",
        "term_idx":"Recreational works",
        "term_type":"genreform",
        "record_id":"gf2014026164",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026164"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2011026398",
        "term":"Military television programs",
        "term_idx":"Military television programs",
        "term_idx":"Military television programs",
        "term_type":"genreform",
        "record_id":"gf2011026398",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2011026398"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026522",
        "term":"Sagas",
        "term_idx":"Sagas",
        "term_idx":"Sagas",
        "term_type":"genreform",
        "record_id":"gf2014026522",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026522"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2017026118",
        "term":"Film posters",
        "term_idx":"Film posters",
        "term_idx":"Film posters",
        "term_type":"genreform",
        "record_id":"gf2017026118",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2017026118"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2011026322",
        "term":"Horror radio programs",
        "term_idx":"Horror radio programs",
        "term_idx":"Horror radio programs",
        "term_type":"genreform",
        "record_id":"gf2011026322",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2011026322"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026595",
        "term":"Western plays",
        "term_idx":"Western plays",
        "term_idx":"Western plays",
        "term_type":"genreform",
        "record_id":"gf2014026595",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026595"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2011026279",
        "term":"Filmed speeches",
        "term_idx":"Filmed speeches",
        "term_idx":"Filmed speeches",
        "term_type":"genreform",
        "record_id":"gf2011026279",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2011026279"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026466",
        "term":"Pantoums",
        "term_idx":"Pantoums",
        "term_idx":"Pantoums",
        "term_type":"genreform",
        "record_id":"gf2014026466",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026466"},
      {
        "uri":"http://id.loc.gov/authorities/genreForms/gf2014026988",
        "term":"Paso dobles (Music)",
        "term_idx":"Paso dobles (Music)",
        "term_idx":"Paso dobles (Music)",
        "term_type":"genreform",
        "record_id":"gf2014026988",
        "language":"en",
        "authority_code":"lcgft",
        "authority_name":"Library of Congress Genre/Form Terms for Library and Archival Materials",
        "unique_id":"lcgft_gf2014026988"}]
  }}
```