### PR TITLE
[KK] Using matching to speed up scan_each method where possible.

### DIFF
--- a/lib/tripple_to_solr_doc.rb
+++ b/lib/tripple_to_solr_doc.rb
@@ -86,7 +86,7 @@ class TrippleToSolrDoc
     #  <http://id.loc.gov/vocabulary/graphicMaterials/tgm003368> <http://www.loc.gov/mads/rdf/v1#adminMetadata> _:bnode12683670136320746870
     #  ...and looking at _:bnode12683670136320746870
     #  :bnode12683670136320746870 <http://id.loc.gov/ontologies/RecordInfo#recordStatus'> "deprecated"
-    @@redis.scan_each do |subject|
+    @@redis.scan_each(match: "http*") do |subject|
       attributes = Marshal.load(@@redis.get(subject))
       change_history = attributes['http://www.loc.gov/mads/rdf/v1#adminMetadata']
       bnode_for_this = @@redis.get(change_history)
@@ -102,8 +102,8 @@ class TrippleToSolrDoc
     @@logger.info("after weeding out deprecated there were #{@@redis.dbsize}")
 
     # Weed out bnodes, you have to do this after weeding out deprecateds, not at the same time
-    @@redis.scan_each do |subject|
-      @@redis.del(subject) unless subject.include?('http')
+    @@redis.scan_each(match: "*bnode*") do |subject|
+      @@redis.del(subject)
     end
 
     @@logger.info("after weeding out bnodes there were #{@@redis.dbsize}")


### PR DESCRIPTION
So in testing this, the numbers come out the same, but it is slightly faster. Particularly where it limits the match to only things starting with "http," as there are far more bnodes than anything else. For the tested vocabulary, limiting the scope took 1/3 the time and doing a full scan. 

> {"level":"INFO","message":"before weeding out there were 48768","timestamp":"2019-09-05T**17:53:57**.978+0000"}
> {"level":"INFO","message":"after weeding out deprecated there were 43586","timestamp":"2019-09-05T**17:56:28**.419+0000"}
> {"level":"INFO","message":"after weeding out bnodes there were 7432","timestamp":"2019-09-05T**17:57:23**.659+0000"}
> {"level":"DEBUG","message":"deleting by query: authority_code:lctgm","timestamp":"2019-09-05T17:57:36.926+0000"}
> {"level":"INFO","message":"delete response: {\"responseHeader\"=>{\"status\"=>0, \"QTime\"=>39}}","timestamp":"2019-09-05T17:57:37.012+0000"}
> {"level":"INFO","message":"commit response: {\"responseHeader\"=>{\"status\"=>0, \"QTime\"=>138}}","timestamp":"2019-09-05T17:57:37.180+0000"}
> {"level":"INFO","message":"Finished posting graphic_materials from /opt/authoritydata_udpater/graphicMaterials.both.nt to http://solr:8983/solr","timestamp":"2019-09-05T17:57:49.248+0000"}

vs with the match ... 

> {"level":"INFO","message":"before weeding out there were 48768","timestamp":"2019-09-05T**19:13:38**.641+0000"}
> {"level":"INFO","message":"after weeding out deprecated there were 43586","timestamp":"2019-09-05T**19:14:30**.583+0000"}
> {"level":"INFO","message":"after weeding out bnodes there were 7432","timestamp":"2019-09-05T**19:15:26**.387+0000"}
> {"level":"DEBUG","message":"deleting by query: authority_code:lctgm","timestamp":"2019-09-05T19:15:40.043+0000"}
> {"level":"INFO","message":"delete response: {\"responseHeader\"=>{\"status\"=>0, \"QTime\"=>18}}","timestamp":"2019-09-05T19:15:40.101+0000"}
> {"level":"INFO","message":"commit response: {\"responseHeader\"=>{\"status\"=>0, \"QTime\"=>123}}","timestamp":"2019-09-05T19:15:40.249+0000"}
> {"level":"INFO","message":"Finished posting graphic_materials from /opt/authoritydata_udpater/graphicMaterials.both.nt to http://solr:8983/solr","timestamp":"2019-09-05T19:15:52.203+0000"}