### PR TITLE
Support AAT

### DIFF
--- a/01_clean_nt_file.rb
+++ b/01_clean_nt_file.rb
@@ -8,7 +8,9 @@ WORTHWHILE_PREDICATES = [
   'http://www.loc.gov/mads/rdf/v1#adminMetadata',
   'http://id.loc.gov/ontologies/RecordInfo#recordStatus',
   'http://www.loc.gov/mads/rdf/v1#authoritativeLabel',
-  'http://www.w3.org/2004/02/skos/core#prefLabel'
+  'http://www.w3.org/2004/02/skos/core#prefLabel',
+  'http://www.w3.org/2004/02/skos/core#altLabel',
+  'http://www.w3.org/2000/01/rdf-schema#label'
 ].freeze
 
 input_file = File.open(ARGV[0], 'r')

--- a/02_convert_to_solr_docs.rb
+++ b/02_convert_to_solr_docs.rb
@@ -5,7 +5,7 @@ require 'optparse'
 require File.join(__dir__, 'lib', 'vocabulary_parser')
 
 options = {}
-SUPPORTED_VOCABULARIES = ['rdacarriers', 'graphic_materials', 'genre_and_form', 'names', 'subjects'].freeze
+SUPPORTED_VOCABULARIES = ['rdacarriers', 'graphic_materials', 'genre_and_form', 'names', 'subjects', 'aat'].freeze
 
 opt_parser = OptionParser.new do |opts|
   opts.banner = 'Usage: ruby authoritydata_updater.rb [options] \n Exaxmple: ruby authoritydata_updater.rb --vocabulary genre_and_form --source ./authority-file.nt'

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the optional `-n` and `-d` flags that can be used to resume parsing.
 
     Usage: ruby authoritydata_updater.rb [options] \n Exaxmple: ruby authoritydata_updater.rb --vocabulary genre_and_form --source ./authority-file.nt
 
-    Supported vocabularies: rdacarriers, graphic_materials, genre_and_form, names, subjects
+    Supported vocabularies: rdacarriers, graphic_materials, genre_and_form, names, subjects, aat
 
         -v, --vocabulary=                The type of vocabularies in the source file
         -s, --source=                    Path or URL to vocabulary file
@@ -124,7 +124,8 @@ It is not deployed to any remote environments.
 -   [Genre & Form Terms (as N-Tripple/nt file)](http://id.loc.gov/static/data/downloads/authoritiesgenreForms.nt.madsrdf.zip)
 -   [Graphic Materials (as N-Tripple/nt file)](http://id.loc.gov/static/data/downloads/vocabularygraphicMaterials.nt.both.zip)
 -   [Names (as N-Tripple/nt file)](http://id.loc.gov/authorities/names.nt)
--   [Subjects (as N-Tripple/nt file)](//id.loc.gov/static/data/downloads/authoritiessubjects.nt.madsrdf.zip)
+-   [Subjects (as N-Tripple/nt file)](http://id.loc.gov/static/data/downloads/authoritiessubjects.nt.madsrdf.zip)
+-   [Gatty AAT (as N-Tripple/nt file)](http://vocab.getty.edu/) (Documentation and Downloads > Datasets > AAT)
 
 ## Adding A New Vocabulary
 

--- a/lib/tripple_to_solr_doc.rb
+++ b/lib/tripple_to_solr_doc.rb
@@ -108,21 +108,31 @@ class TrippleToSolrDoc
 
       new_document = {
         uri: subject,
-        term: attributes.dig('http://www.loc.gov/mads/rdf/v1#authoritativeLabel'),
-        term_idx: attributes.dig('http://www.loc.gov/mads/rdf/v1#authoritativeLabel'),
+        term: look_for_term(attributes),
+        term_idx: look_for_term(attributes),
         term_type: term_type == :auto ? detect_term_type(attributes) : term_type,
         record_id: File.basename(subject),
         language: 'en',
         authority_code: authority_code,
         authority_name: authority_name,
         unique_id: "#{unique_id_prefix}_#{File.basename(subject)}",
-        alternate_term_idx: attributes.dig('http://www.w3.org/2004/02/skos/core#prefLabel'),
-        alternate_term: attributes.dig('http://www.w3.org/2004/02/skos/core#prefLabel')
+        alternate_term_idx: look_for_alt_terms(attributes),
+        alternate_term: look_for_alt_terms(attributes)
       }
 
       output_json_file.puts(JSON.generate(new_document))
     end
     output_json_file.close
+  end
+
+  # Terms are stored in different places depending on LOC or Getty
+  def self.look_for_term(attributes)
+    attributes.dig('http://www.loc.gov/mads/rdf/v1#authoritativeLabel')
+  end
+
+  # Alternate Terms are stored in different places depending on LOC or Getty
+  def self.look_for_alt_terms(attributes)
+    attributes.dig('http://www.w3.org/2004/02/skos/core#prefLabel')
   end
 
   def self.delete_and_compact

--- a/lib/vocabulary_parser.rb
+++ b/lib/vocabulary_parser.rb
@@ -23,6 +23,8 @@ class VocabularyParser
       generate_name_solr_docs(@source)
     when 'subjects'
       generate_subject_solr_docs(@source)
+    when 'aat'
+      generate_aat_solr_docs(@source)
     end
     # @logger.info("Finished posting #{@vocabulary} from #{@source} to #{@solr_url}")
   end
@@ -35,6 +37,17 @@ class VocabularyParser
       authority_code: 'naf',
       authority_name: 'LC/NACO authority file',
       unique_id_prefix: 'naf'
+    )
+  end
+
+  def generate_aat_solr_docs(source)
+    solr_docs = TrippleToSolrDoc.convert!(file: source,
+      term_type: 'concept',
+      start_at_line: @start_at_line,
+      db_file_name: @db_file_name,
+      authority_code: 'aat',
+      authority_name: 'Art and Architecture Thesaurus',
+      unique_id_prefix: 'aat'
     )
   end
 


### PR DESCRIPTION
This PR adds support for Getty AAT vocabulary (http://vocab.getty.edu/) (linked to in README.md).
I've run genre and form through this branch to confirm the final output file hasn't been affected by these changes.
